### PR TITLE
Added ARM64 support

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,3 +1,6 @@
+# 0.3.2
+- Added ARM64 support.
+
 # 0.3.1
 - Added unit selection in settings
 

--- a/NetStats.csproj
+++ b/NetStats.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.22621</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Platforms>x64</Platforms>
+    <Platforms>AnyCPU</Platforms>
 
     <PackageId>NetStats</PackageId>
     <Title>NetStats</Title>
-    <Version>0.3.1</Version>
-    <AssemblyVersion>0.1.67.0</AssemblyVersion>
-    <FileVersion>0.1.67.0</FileVersion>
+    <Version>0.3.2</Version>
+    <AssemblyVersion>0.1.68.0</AssemblyVersion>
+    <FileVersion>0.1.68.0</FileVersion>
     <Description>An extension providing real-time network statistics.</Description>
     <Authors>Timothy Franceschi</Authors>
     <PackageProjectUrl>https://github.com/TimothyFran/NetStats</PackageProjectUrl>
@@ -25,7 +25,7 @@
     <None Include="Assets/netstats.png" Pack="true" PackagePath="\Assets\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="WindowSill.API" Version="0.8.0" />
+    <PackageReference Include="WindowSill.API" Version="0.9.20" />
   </ItemGroup>
   <PropertyGroup>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>

--- a/NetStats.sln
+++ b/NetStats.sln
@@ -7,14 +7,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStats", "NetStats.csproj
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
+		Debug|AnyCPU = Debug|AnyCPU
+		Release|AnyCPU = Release|AnyCPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6578A45D-5E53-C8FE-CA44-954D0F79C0EB}.Debug|x64.ActiveCfg = Debug|x64
-		{6578A45D-5E53-C8FE-CA44-954D0F79C0EB}.Debug|x64.Build.0 = Debug|x64
-		{6578A45D-5E53-C8FE-CA44-954D0F79C0EB}.Release|x64.ActiveCfg = Release|x64
-		{6578A45D-5E53-C8FE-CA44-954D0F79C0EB}.Release|x64.Build.0 = Release|x64
+		{6578A45D-5E53-C8FE-CA44-954D0F79C0EB}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
+		{6578A45D-5E53-C8FE-CA44-954D0F79C0EB}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
+		{6578A45D-5E53-C8FE-CA44-954D0F79C0EB}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
+		{6578A45D-5E53-C8FE-CA44-954D0F79C0EB}.Release|AnyCPU.Build.0 = Release|AnyCPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request updates the project configuration and upgrades WindowSill.API to prepare NetStats for ARM64 support in WindowSill. The extension is now built as AnyCPU, ensuring compatibility with both x64 and ARM64 environments.

Please publish an updated version of this extension as soon as possible.

**Planned rollout sequence:**

1. WindowSill 0.9.20 will be released as x64-only. Users will update to this version while continuing to run the x64 build on ARM devices (via emulation).
1. WindowSill 0.9.20 will download extensions that use WindowSill.API 0.9.20 (earlier versions of WindowSill won't update extensions due to incompatibility).
1. A later release will introduce the ARM64 build of WindowSill.
1. When this occurs, users currently running the x64 version on ARM devices will automatically transition to the ARM64 build.
1. Extensions that are not compatible with ARM64 at that time will stop working.

Publishing this update ensures the extension remains functional when the ARM64 version of WindowSill is released.

Thanks!